### PR TITLE
Remove link decoration on hover in header menu

### DIFF
--- a/blocks/menu/__item/menu__item.css
+++ b/blocks/menu/__item/menu__item.css
@@ -13,6 +13,7 @@
     color: #111;
     background-color: #FFF;
     cursor: pointer;
+    text-decoration: none;
 }
 
 @media screen and (min-width: 35.5em) {


### PR DESCRIPTION
I think that non-underlined links in menu it's better for UI.
