### PR TITLE
fix: replace OOCSS link to stubbornella wiki (prevents casino redirect)

### DIFF
--- a/src/pages/introduction.mdx
+++ b/src/pages/introduction.mdx
@@ -19,7 +19,7 @@ This is also true for long-term projects with legacy code (read ["How to Scale a
 
 There are plenty of [methodologies](https://github.com/awesome-css-group/awesome-css#naming-conventions--methodologies-bulb) out there aiming to reduce the CSS footprint, organize cooperation among programmers and maintain large CSS codebases. This is obvious in large projects like Twitter, Facebook and [GitHub](http://markdotto.com/2014/07/23/githubs-css/#two-bundles), but other projects often grow into some “Huge CSS file” state pretty quickly.
 
-- [OOCSS](http://oocss.org/) — Separating container and content with CSS “objects”
+- [OOCSS](https://github.com/stubbornella/oocss/wiki) — Object oriented CSS
 - [SMACSS](http://smacss.com/) — Style-guide to write your CSS with five categories for CSS rules
 - [SUITCSS](https://suitcss.github.io/) — Structured class names and meaningful hyphens
 - [Atomic](https://acss.io/) — Breaking down styles into atomic, or indivisible, pieces


### PR DESCRIPTION
## Description

Replace the OOCSS link from the defunct `http://oocss.org/` domain (now redirecting to a casino site) to the official wiki maintained by the author Nicole Sullivan: `https://github.com/stubbornella/oocss/wiki`

This is a preventive contribution to maintain the integrity and usefulness of the documentation.

## Changes
- Updated OOCSS link from `http://oocss.org/` to `https://github.com/stubbornella/oocss/wiki`
- Updated description from "Separating container and content with CSS objects" to "Object oriented CSS"